### PR TITLE
Ruby 3.0 compatibility

### DIFF
--- a/lib/mlb/team.rb
+++ b/lib/mlb/team.rb
@@ -25,7 +25,7 @@ module MLB
       # connection error, in which case read from a fixture file
       @all ||= begin
         results_to_team(results_from_freebase)
-      rescue Faraday::Error::ConnectionFailed, Faraday::Error::TimeoutError
+      rescue Faraday::ConnectionFailed, Faraday::Error::TimeoutError
         results_to_team(results_from_cache)
       end
     end

--- a/mlb.gemspec
+++ b/mlb.gemspec
@@ -4,9 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'mlb/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['~> 0.8', '< 0.10']
-  spec.add_dependency 'faraday_middleware', '~> 0.9'
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
   spec.author = 'Erik Michaels-Ober'
   spec.description = 'MLB.rb is a Ruby library for retrieving current Major League Baseball players, managers, teams, divisions, and leagues.'
   spec.email = 'sferik@gmail.com'


### PR DESCRIPTION
Pre 1.0 releases of faraday is not compatible with Ruby 3.0.